### PR TITLE
期限が過ぎたタスクをアラートで表示

### DIFF
--- a/.idea/task-management.iml
+++ b/.idea/task-management.iml
@@ -1901,6 +1901,24 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library">
+      <library name="timecop (vbundled(0.9.1)) [path][gem]" type="rubylib">
+        <properties>
+          <option name="version" value="4" />
+        </properties>
+        <CLASSES>
+          <root url="file://$MODULE_DIR$/vendor/bundle/ruby/2.6.0/gems/timecop-0.9.1/lib" />
+          <root url="file://$MODULE_DIR$/vendor/bundle/ruby/2.6.0/gems/timecop-0.9.1/test" />
+        </CLASSES>
+        <SOURCES>
+          <root url="file://$MODULE_DIR$/vendor/bundle/ruby/2.6.0/gems/timecop-0.9.1/lib" />
+          <root url="file://$MODULE_DIR$/vendor/bundle/ruby/2.6.0/gems/timecop-0.9.1/test" />
+        </SOURCES>
+        <excluded>
+          <root url="file://$MODULE_DIR$/vendor/bundle/ruby/2.6.0/gems/timecop-0.9.1/test" />
+        </excluded>
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
       <library name="turbolinks (vbundled(5.2.0)) [path][gem]" type="rubylib">
         <properties>
           <option name="version" value="4" />

--- a/Gemfile
+++ b/Gemfile
@@ -81,3 +81,5 @@ gem 'ransack'
 
 # Pagination
 gem 'kaminari'
+
+gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,7 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
+    timecop (0.9.1)
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -304,6 +305,7 @@ DEPENDENCIES
   slim-rails
   spring
   spring-watcher-listen (~> 2.0.0)
+  timecop
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -57,7 +57,7 @@ class Admin::UsersController < ApplicationController
 
   def user_params
     params.require(:user)
-          .permit(:name, :email, :admin, :password, :password_confirmation)
+          .permit(:name, :email, :admin, :password, :password_confirmation, :image)
   end
 
   def require_admin

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -8,6 +8,8 @@ class TasksController < ApplicationController
   def index
     # グループに属している場合はグループに関連するタスク表示
     # 所属していない場合は自分のタスクのみ表示
+    @expired_tasks = Task.expired.where(user_id: current_user.id)
+
     @q = if current_user.admin?
            Task.all
          elsif current_user.group.present?

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -17,6 +17,7 @@ class Task < ApplicationRecord
   scope :recent, -> { order(created_at: :desc) }
   scope :with_group, ->(group) { includes(user: :group).where(groups: { id: group&.id }) }
   scope :expired, -> { where('deadline <= ?', Time.zone.now) }
+
   # ransack使用時の制約追加
   def self.ransackable_attributes(_auth_object = nil)
     %w[name created_at deadline state]

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
-  # enum state: { 未着手: '未着手', '着手中': '着手中', 完了: '完了' }
+
   enum state: { waiting: 0, working: 1, completed: 2 }
   belongs_to :user
   belongs_to :owner, class_name: 'User'

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -16,7 +16,7 @@ class Task < ApplicationRecord
 
   scope :recent, -> { order(created_at: :desc) }
   scope :with_group, ->(group) { includes(user: :group).where(groups: { id: group&.id }) }
-
+  scope :expired, -> { where('deadline <= ?', Date.today) }
   # ransack使用時の制約追加
   def self.ransackable_attributes(_auth_object = nil)
     %w[name created_at deadline state]

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -16,7 +16,7 @@ class Task < ApplicationRecord
 
   scope :recent, -> { order(created_at: :desc) }
   scope :with_group, ->(group) { includes(user: :group).where(groups: { id: group&.id }) }
-  scope :expired, -> { where('deadline <= ?', Date.today) }
+  scope :expired, -> { where('deadline <= ?', Time.zone.now) }
   # ransack使用時の制約追加
   def self.ransackable_attributes(_auth_object = nil)
     %w[name created_at deadline state]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,10 +7,22 @@ class User < ApplicationRecord
   has_many :owner_tasks, class_name: 'Task', foreign_key: :owner_id
   has_one :user_group, dependent: :destroy
   has_one :group, through: :user_group
+  has_one_attached :image
 
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i.freeze
   validates :name, presence: true, length: { maximum: 30 }
   validates :email, presence: true, length: { maximum: 255 }, uniqueness: true, format: { with: VALID_EMAIL_REGEX }
   validates :password, presence: true, confirmation: true, length: { minimum: 6 }
   validates :password_digest, presence: true
+
+  validate :image_type
+
+  private
+
+  def image_type
+    if image.attached?
+      errors.add(:image, I18n.t('errors.messages.task.image.different_type', locale: :ja)) unless image.content_type.in?(%("image/jpeg image/png"))
+    end
+  end
+
 end

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -23,4 +23,7 @@
   .form-group
     = f.label :password_confirmation, User.human_attribute_name(:password_confirmation)
     = f.password_field :password_confirmation, class: 'form-control', placeholder: I18n.t('message.users.password_confirmation.insert')
+  .form-group
+    = f.label :image
+    = f.file_field :image, class: 'form-control'
   = f.submit nil, class: 'btn btn-primary'

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -22,7 +22,7 @@ table.table.table-hover
       td= @user.admin? ? I18n.t('users.index.yes') : I18n.t('users.index.no')
     tr
       th= User.human_attribute_name(:image)
-      td= image_tag @user.image if @user.image.attached?
+      td= image_tag @user.image.variant(resize:'300x300').processed if @user.image.attached?
     tr
       th= User.human_attribute_name(:created_at)
       td= l(@user.created_at, format: :long)

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -21,6 +21,9 @@ table.table.table-hover
       th= User.human_attribute_name(:admin)
       td= @user.admin? ? I18n.t('users.index.yes') : I18n.t('users.index.no')
     tr
+      th= User.human_attribute_name(:image)
+      td= image_tag @user.image if @user.image.attached?
+    tr
       th= User.human_attribute_name(:created_at)
       td= l(@user.created_at, format: :long)
     tr

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -13,6 +13,7 @@ html
 
       ul.navbar-nav.ml-auto
         - if current_user
+          li.nav-item= link_to "ユーザー名：#{current_user.name}", tasks_path, class: 'nav-link'
           li.nav-item= link_to I18n.t('tasks.index.title'), tasks_path, class: 'nav-link'
           - if current_user.admin?
             li.nav-item= link_to I18n.t('users.index.title'), admin_users_path, class: 'nav-link'

--- a/app/views/tasks/_expered_alert.html.slim
+++ b/app/views/tasks/_expered_alert.html.slim
@@ -1,0 +1,5 @@
+.alert class="alert-warning"
+  | 期限切れのタスクがあります
+  ul#error_explanation
+    - expired_tasks.each do |task|
+      li= link_to task.name, task

--- a/app/views/tasks/_expered_alert.html.slim
+++ b/app/views/tasks/_expered_alert.html.slim
@@ -1,5 +1,5 @@
 .alert class="alert-warning"
-  | 期限切れのタスクがあります
+  | #{I18n.t('message.tasks.expered')}
   ul#error_explanation
     - expired_tasks.each do |task|
       li= link_to task.name, task

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -18,7 +18,7 @@
   .form-group
     .col-sm-12
       = f.label :deadline
-      = f.date_select :deadline, {}, class: 'form-control date-picker', id: 'task_deadline'
+      = f.datetime_select :deadline, {}, class: 'col-sm-1 form-control date-picker', id: 'task_deadline'
   .form-group
     .col-sm-12
       = f.label :state

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -18,7 +18,8 @@
   .form-group
     .col-sm-12
       = f.label :deadline
-      = f.datetime_select :deadline, {}, class: 'col-sm-1 form-control date-picker', id: 'task_deadline'
+      = f.datetime_select :deadline, {include_blank: true, use_month_numbers: true, date_separator: ' / '},
+              class: 'col-sm-1 col-form-control date-picker', id: 'task_deadline'
   .form-group
     .col-sm-12
       = f.label :state

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -1,3 +1,5 @@
+= render partial: 'expered_alert', locals: {expired_tasks: @expired_tasks} if @expired_tasks.present?
+
 h1 = I18n.t('tasks.index.title')
 
 .card

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -30,7 +30,7 @@ table.table.table-hover
       td= @task.owner.name
     tr
       th= Task.human_attribute_name(:image)
-      td= image_tag @task.image if @task.image.attached?
+      td= image_tag @task.image.variant(resize:'300x300').processed if @task.image.attached?
 
 = link_to I18n.t('button.edit'), edit_task_path, class: 'btn btn-primary mr-3'
 = link_to I18n.t('button.destroy'), @task, method: :delete, remote: true,

--- a/config/locales/message.ja.yml
+++ b/config/locales/message.ja.yml
@@ -7,6 +7,7 @@ ja:
       destroy: "タスク「%{name}」を削除しました"
       destroy_check: "タスク「%{name}」を削除します。よろしいですか？"
       editable: "タスク「%{name}」の操作権限がありません"
+      expered: 期限切れのタスクがあります
       name:
         insert: タスク名を入力してください
       description:

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -23,6 +23,7 @@ ja:
         group: グループ
         password: パスワード
         password_confirmation: パスワード（確認）
+        image: プロフィール画像
         created_at: 登録日時
         updated_at: 更新日時
       group:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,7 +26,7 @@ end
   end
 end
 
-100.times do |n|
+50.times do |n|
   case n % 5
   when 0 then
     FactoryBot.create(:task, state: rand(3), name: "タイトル_#{n}", user: User.first, owner: User.first)


### PR DESCRIPTION
### 概要
- ログインした時点で、ホーム画面にて期限の過ぎたタスクを表示

#60 を実装しました。

### 詳細
- `deadline`と現在時刻を比較することで期限切れタスクとして表示するか判断
- 期限切れタスクは黄色いアラートで表示
- リンクで設定しているため直接タスクに飛べるようにしている

### インストールしたGem
- `timecop`
  - 時間操作を行いたいため

### 実装画面
<img width="700" alt="スクリーンショット 2019-05-27 11 36 18" src="https://user-images.githubusercontent.com/24800838/58392170-ae936380-8073-11e9-8d10-944a41f71140.png">
